### PR TITLE
Set USE_CUSTOM_LIBFFI when compiling for simulator

### DIFF
--- a/MABlockClosure.h
+++ b/MABlockClosure.h
@@ -2,7 +2,7 @@
 #import <Foundation/Foundation.h>
 
 
-#if TARGET_OS_IPHONE && TARGET_OS_EMBEDDED
+#if (TARGET_OS_IPHONE && TARGET_OS_EMBEDDED) || TARGET_IPHONE_SIMULATOR
 #define USE_CUSTOM_LIBFFI 1
 #endif
 


### PR DESCRIPTION
This allows the library to compile against iPhone Simulator targets. 
